### PR TITLE
chore: remove redundant setState

### DIFF
--- a/lib/src/flutter_lazy_indexed_stack.dart
+++ b/lib/src/flutter_lazy_indexed_stack.dart
@@ -53,10 +53,7 @@ class _LazyIndexedStackState extends State<LazyIndexedStack> {
 
   void _activateChild(int? index) {
     if (index == null) return;
-
-    if (!_activatedChildren[index]) {
-      setState(() => _activatedChildren[index] = true);
-    }
+    if (!_activatedChildren[index]) _activatedChildren[index] = true;
   }
 
   List<Widget> get children {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

A `setState()` was used inside of the `didUpdateWidget()` method which is technically unnecessary as the flutter framework calls the `build()` method immediately after `didUpdateWidget()` is invoked.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore